### PR TITLE
Save theme changes to local storage. Resolves #71, fixes #89

### DIFF
--- a/src/common/context/themeContext.js
+++ b/src/common/context/themeContext.js
@@ -1,16 +1,28 @@
 import { ThemeProvider } from 'styled-components';
-import { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 import { theme } from '../../common/constants/theme';
 
 const ThemeSelectorContext = createContext(null);
 
 export const useThemeSelectorContext = () => useContext(ThemeSelectorContext);
 
-const ThemeContextProvider = ({children}) => {
+const ThemeContextProvider = ({ children }) => {
   const [currentTheme, setTheme] = useState('light');
+  useEffect(() => {
+    const localStorageTheme = localStorage.getItem("theme")
+    const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+    if (localStorageTheme) {
+      changeTheme(localStorageTheme === 'light')
+    }
+    else {
+      changeTheme(prefersLight)
+    }
+  }, [])
 
-  const changeTheme = value => {
-    setTheme(value ? 'light' : 'dark');
+  const changeTheme = isLightTheme => {
+    const newTheme = isLightTheme ? 'light' : 'dark'
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme)
   }
   return (
     <ThemeProvider theme={theme[currentTheme]}>

--- a/src/components/switch/switch.jsx
+++ b/src/components/switch/switch.jsx
@@ -1,11 +1,22 @@
 import './switch.scss';
 import { useTheme } from 'styled-components';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const Switch = ({onChange}) => {
   const theme = useTheme();
 
   const [checked, setChecked] = useState(true);
+
+  useEffect(() => {
+    const localStorageTheme = localStorage.getItem("theme")
+    const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
+    if(localStorageTheme){
+      setChecked(localStorageTheme === 'light')
+    }
+    else{
+      setChecked(prefersLight)
+    }
+  }, [])
 
   const onCheckboxChange = event => {
     const newState = event.target.checked;


### PR DESCRIPTION
Theme changes are now saved after page reloads. Also added detection for user preferences on dark theme, which is used when there is no local storage data about chosen theme.