### PR TITLE
Local storage saves and fixes, resolves #56

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^11.2.7",
     "@testing-library/user-event": "^12.8.3",
     "axios": "^0.24.0",
+    "clsx": "^1.2.0",
     "moment": "^2.29.2",
     "node-sass": "^7.0.1",
     "react": "^17.0.2",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -7,20 +7,22 @@ import { GroupContextProvider } from '../common/context/groupContext';
 import { LecturerContextProvider } from '../common/context/lecturerContext';
 import { PreloadedListsContextProvider } from '../common/context/preloadedListsContext';
 import { useCurrentDateParams } from '../common/utils/useCurrentDateParams';
+import ScrollToTop from '../containers/scrollToTop/index';
 
 function App() {
-  const {currentWeek} = useCurrentDateParams()
-
+  const { currentWeek } = useCurrentDateParams()
   return (
     <WeekContextProvider initialValue={currentWeek === 1 ? 'firstWeek' : 'secondWeek'}>
       <PreloadedListsContextProvider>
         <GroupContextProvider>
           <ThemeContextProvider initialValue={null}>
             <LecturerContextProvider>
-              <Wrapper>
-                <Navbar/>
-                <ScheduleRouter/>
-              </Wrapper>
+              <ScrollToTop>
+                <Wrapper>
+                  <Navbar />
+                  <ScheduleRouter />
+                </Wrapper>
+              </ScrollToTop>
             </LecturerContextProvider>
           </ThemeContextProvider>
         </GroupContextProvider>

--- a/src/common/constants/subjectTypes.js
+++ b/src/common/constants/subjectTypes.js
@@ -1,0 +1,16 @@
+import { ScheduleItemTypeLab, ScheduleItemTypeLec, ScheduleItemTypePrac } from "../../components/scheduleItemContent/scheduleItemContent.style";
+
+export const SUBJECT_TYPES = {
+    lec: {
+        component: ScheduleItemTypeLec,
+        title: "Лек"
+    },
+    lab: {
+        component: ScheduleItemTypeLab,
+        title: "Лаб"
+    },
+    prac: {
+        component: ScheduleItemTypePrac,
+        title: "Прак"
+    },
+}

--- a/src/common/context/themeContext.js
+++ b/src/common/context/themeContext.js
@@ -1,6 +1,7 @@
 import { ThemeProvider } from 'styled-components';
 import { createContext, useContext, useEffect, useState } from 'react';
 import { theme } from '../../common/constants/theme';
+import { getLocalStorageItem, setLocalStorageItem } from '../utils/parsedLocalStorage';
 
 const ThemeSelectorContext = createContext(null);
 
@@ -9,7 +10,7 @@ export const useThemeSelectorContext = () => useContext(ThemeSelectorContext);
 const ThemeContextProvider = ({ children }) => {
   const [currentTheme, setTheme] = useState('light');
   useEffect(() => {
-    const localStorageTheme = localStorage.getItem("theme")
+    const localStorageTheme = getLocalStorageItem("theme")
     const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
     if (localStorageTheme) {
       changeTheme(localStorageTheme === 'light')
@@ -22,7 +23,7 @@ const ThemeContextProvider = ({ children }) => {
   const changeTheme = isLightTheme => {
     const newTheme = isLightTheme ? 'light' : 'dark'
     setTheme(newTheme);
-    localStorage.setItem("theme", newTheme)
+    setLocalStorageItem("theme", newTheme)
   }
   return (
     <ThemeProvider theme={theme[currentTheme]}>

--- a/src/common/utils/apiTransformers.js
+++ b/src/common/utils/apiTransformers.js
@@ -1,10 +1,14 @@
+import { unique } from "./unique";
+
 export const prepareList = (list) => {
-  return list
-    .map((item) => ({
+  return unique(
+    list.map((item) => ({
       label: item.name,
       value: item.id,
     }))
-    .sort((a, b) => {
-      return a.label.localeCompare(b.label, "uk")
-    });
+      .filter(item => item.label !== "" && item.value !== "")
+      .sort((a, b) => {
+        return a.label.localeCompare(b.label, "uk")
+      }),
+    (item => item.label));
 };

--- a/src/common/utils/parsedLocalStorage.js
+++ b/src/common/utils/parsedLocalStorage.js
@@ -1,0 +1,7 @@
+export const setLocalStorageItem = (key, value) => {
+    localStorage.setItem(key, JSON.stringify(value))
+}
+
+export const getLocalStorageItem = (key) => {
+    return JSON.parse(localStorage.getItem(key))
+}

--- a/src/common/utils/unique.js
+++ b/src/common/utils/unique.js
@@ -1,0 +1,7 @@
+export const unique = (array, getComparingItem = (item) => item) => {
+    const uniqueFilter = (value, index, self) => {
+        return self.map(e => getComparingItem(e)).indexOf(getComparingItem(value)) === index;
+    }
+
+    return [...array.filter(uniqueFilter)];
+}

--- a/src/components/entitySearch/entitySearch.jsx
+++ b/src/components/entitySearch/entitySearch.jsx
@@ -41,40 +41,47 @@ const EntitySearch = () => {
     } else {
       setLecturer(null);
     }
-  }, [isLecturer]);
+  }, [isLecturer, setGroup, setLecturer]);
 
   useEffect(() => {
     if (isLecturer) {
-      const lecturer = query.get("lecturerId");
+      let lecturer = query.get("lecturerId");
+      const localStorageLecturerId = localStorage.getItem("lecturerId")
+      if(!lecturer && localStorageLecturerId){
+        lecturer = localStorageLecturerId
+        history.push("?lecturerId=" + localStorageLecturerId);
+      }
       setLecturer(lecturer);
       setGroup(null);
     } else {
-      const group = query.get("groupId");
-      let groupObj = list.find((g) => g.id === group);
+      let group = query.get("groupId");
+      const localStorageLecturerId = localStorage.getItem("groupId")
+      if(!group && localStorageLecturerId){
+        group = localStorageLecturerId
+        history.push("?groupId=" + localStorageLecturerId);
+      }
+      const groupObj = list.find((g) => g.id === group);
       setGroup(groupObj);
       setLecturer(null);
     }
-
     setOptions(prepareList(list));
-  }, [list]);
+  }, [list, history, isLecturer, query, setGroup, setLecturer]);
 
   const onOptionChange = (option) => {
     isLecturer ? setLecturer(option.value) : setGroup({ id : option.value, name : option.label });
 
     if (isLecturer) {
       history.push("?lecturerId=" + option.value);
+      localStorage.setItem("lecturerId", option.value)
     } else {
       history.push("?groupId=" + option.value);
+      localStorage.setItem("groupId", option.value)
     }
   };
-
   const initialValue =
     options.find((item) =>
       isLecturer ? item.value === lecturer : item.value === group?.id
     ) ?? null;
-
-  console.log(options);
-
   return (
     <Label alignItems="center" gap="15px">
       Розклад занять для

--- a/src/components/entitySearch/entitySearch.jsx
+++ b/src/components/entitySearch/entitySearch.jsx
@@ -14,6 +14,7 @@ import { routes } from "../../common/constants/routes";
 
 import { getSelectCustomStyle } from "../../common/constants/selectOptions";
 import "./entitySearch.scss";
+import { getLocalStorageItem, setLocalStorageItem } from "../../common/utils/parsedLocalStorage";
 
 const useQuery = () => {
   const { search } = useLocation();
@@ -46,7 +47,7 @@ const EntitySearch = () => {
   useEffect(() => {
     if (isLecturer) {
       let lecturer = query.get("lecturerId");
-      const localStorageLecturerId = localStorage.getItem("lecturerId")
+      const localStorageLecturerId = getLocalStorageItem("lecturerId")
       if(!lecturer && localStorageLecturerId){
         lecturer = localStorageLecturerId
         history.push("?lecturerId=" + localStorageLecturerId);
@@ -55,7 +56,7 @@ const EntitySearch = () => {
       setGroup(null);
     } else {
       let group = query.get("groupId");
-      const localStorageLecturerId = localStorage.getItem("groupId")
+      const localStorageLecturerId = getLocalStorageItem("groupId")
       if(!group && localStorageLecturerId){
         group = localStorageLecturerId
         history.push("?groupId=" + localStorageLecturerId);
@@ -72,10 +73,10 @@ const EntitySearch = () => {
 
     if (isLecturer) {
       history.push("?lecturerId=" + option.value);
-      localStorage.setItem("lecturerId", option.value)
+      setLocalStorageItem("lecturerId", option.value)
     } else {
       history.push("?groupId=" + option.value);
-      localStorage.setItem("groupId", option.value)
+      setLocalStorageItem("groupId", option.value)
     }
   };
   const initialValue =

--- a/src/components/scheduleItemContent/scheduleItemContent.jsx
+++ b/src/components/scheduleItemContent/scheduleItemContent.jsx
@@ -1,24 +1,61 @@
-import { GroupName, Location, ScheduleItemCurrent, ScheduleItemHeader, ScheduleItemType, Subject, Teacher,
-   ScheduleItemTypeLab, ScheduleItemTypePrac, ScheduleItemTypeLec } from './scheduleItemContent.style';
+import { GroupName, Location, ScheduleItemCurrent, ScheduleItemHeader, Subject, Teacher,
+  ScheduleItemTypeLab, ScheduleItemTypePrac, ScheduleItemTypeLec, LocationLink } from './scheduleItemContent.style';
 import teacherIcon from '../../assets/icons/teacher.svg';
 import locationIcon from '../../assets/icons/location.svg';
 import { Pictogram, UnstyledLink } from '../../common/styles/styles';
 import { routes } from '../../common/constants/routes';
+import { usePreloadedListContext } from '../../common/context/preloadedListsContext';
+import { unique } from '../../common/utils/unique';
+import { useEffect, useState } from 'react';
+import { useLecturerContext } from '../../common/context/lecturerContext';
+import { useGroupContext } from '../../common/context/groupContext';
 
-const ScheduleItemContent = ({scheduleItemData, collapsed}) => {
-  const type = scheduleItemData && scheduleItemData.type;
+const ScheduleItemContent = ({scheduleItemData, collapsed}) => {  
   const subject = scheduleItemData && scheduleItemData.name;
   const teacher = scheduleItemData && scheduleItemData.teacherName;
   const teacherId = scheduleItemData && scheduleItemData.lecturerId;
-  const location = scheduleItemData && scheduleItemData.place;
-  const groups = scheduleItemData && (scheduleItemData.group || '').split(',');
+  const groups = scheduleItemData && unique((scheduleItemData.group || '').split(','));
   const tag = scheduleItemData && scheduleItemData.tag;
+  const allGroups = usePreloadedListContext().groups;
+  const [location, setLocation] = useState(scheduleItemData && scheduleItemData.place)
+  const {setLecturer} = useLecturerContext()
+  const {setGroup} = useGroupContext()
 
-  console.log(type)
+  useEffect(() => {
+    if(location.endsWith('-')){
+      setLocation(location.slice(0, -1))
+    }
+  }, [location, setLocation])
+
+  const handleLecturerClick = () => {
+    localStorage.setItem("lecturerId", teacherId)
+    setLecturer(teacherId)
+  }
+
+  const handleGroupClick = (groupId) => {
+    return () => {
+      const groupFound = allGroups.find(allGroupsItem => allGroupsItem.name.replace(" ", "") === groupId)
+      if(groupFound){
+        localStorage.setItem("groupId", groupFound.id)
+        setGroup(groupFound.id)
+      }
+    }
+  }
+
+  const getGroupIdByName = (groupName) => {
+    const groupFound = allGroups.find(allGroupsItem => allGroupsItem.name.replace(" ", "") === groupName)
+    if(groupFound){
+      return groupFound.id
+    }
+    else{
+      return ""
+    }
+  }
+
   const getType = () => {  
-    if(tag === "lec") return <ScheduleItemTypeLec>{"Лек"}</ScheduleItemTypeLec>
-    else if(tag === "lab") return <ScheduleItemTypeLab>{"Лаб"}</ScheduleItemTypeLab>
-    else if(tag === "prac") return <ScheduleItemTypePrac>{"Прак"}</ScheduleItemTypePrac>
+    if(tag === "lec") return <ScheduleItemTypeLec>Лек</ScheduleItemTypeLec>
+    else if(tag === "lab") return <ScheduleItemTypeLab>Лаб</ScheduleItemTypeLab>
+    else if(tag === "prac") return <ScheduleItemTypePrac>Прак</ScheduleItemTypePrac>
   } 
 
   return (
@@ -40,21 +77,28 @@ const ScheduleItemContent = ({scheduleItemData, collapsed}) => {
             teacher ?
             <Teacher>
               <Pictogram src={teacherIcon} alt="teacher"/>
-              <UnstyledLink to={routes.LECTURER + `?lecturerId=${teacherId}`}>{teacher}</UnstyledLink>
+              <UnstyledLink onClick={handleLecturerClick} to={routes.LECTURER + `?lecturerId=${teacherId}`}>{teacher}</UnstyledLink>
             </Teacher> : null
           }
           {
             location ?
             <Location>
               <Pictogram src={locationIcon} alt="location"/>
-              {location}
+              {
+              location.split("-")[0] ? 
+              <LocationLink href={`https://kpi.ua/k-${parseInt(location.split("-")[0])}`} target="_blank" rel="noopener noreferrer">{location}</LocationLink>
+              : location
+              } 
             </Location> : null
           }
           <GroupName>
             <div>
               {
                 groups.map((group, idx) => {
-                  return <UnstyledLink key={group} to={routes.GROUP + `?groupName=${group}`}>{group}{idx !== groups.length - 1 ? ', ' : ''}</UnstyledLink>;
+                  return <UnstyledLink onClick={handleGroupClick(group)}
+                  key={group}
+                  to={routes.GROUP + `?groupId=${getGroupIdByName(group)}`}>{group.split("(")[0]}{idx !== groups.length - 1 ? ', ' : ''}
+                  </UnstyledLink>;
                 })
               }
             </div>

--- a/src/components/scheduleItemContent/scheduleItemContent.style.js
+++ b/src/components/scheduleItemContent/scheduleItemContent.style.js
@@ -50,6 +50,11 @@ export const Teacher = styled(Property)`
 export const Location = styled(Property)`
   gap: 7px;
 `;
+
+export const LocationLink = styled.a`
+  color: ${getValueFromTheme('primaryFontColor')};
+  text-decoration: none;
+`
 export const GroupName = styled(Property)`
   gap : 7px
 `;

--- a/src/components/scheduleTypeTab/scheduleTypeTab.jsx
+++ b/src/components/scheduleTypeTab/scheduleTypeTab.jsx
@@ -1,15 +1,37 @@
 import { Tab } from './scheduleTypeTab.style';
 import { useLocation } from 'react-router-dom';
 import { UnstyledLink } from '../../common/styles/styles';
+import { routes } from '../../common/constants/routes';
+import { useEffect, useState } from 'react';
+import { useGroupContext } from '../../common/context/groupContext';
+import { useLecturerContext } from '../../common/context/lecturerContext';
 
 const ScheduleTypeTab = ({tabClick, activeTab, children, url}) => {
   const location = useLocation();
 
   const isActive = location.pathname === url;
+  const { group } = useGroupContext();
+  const { lecturer } = useLecturerContext()
+  const [urlWithParams, setUrlWithParams] = useState(url)
+
+  useEffect(() => {
+    if(url.includes(routes.LECTURER)){
+      const localStorageLecturerId = localStorage.getItem("lecturerId")
+      if(localStorageLecturerId){
+        setUrlWithParams(`${url}?groupId=${localStorageLecturerId}`)
+      }
+    }
+    else if(url.includes(routes.GROUP) || url.includes(routes.SESSION)){
+      const localStorageGroupId = localStorage.getItem("groupId")
+      if(localStorageGroupId){
+        setUrlWithParams(`${url}?groupId=${localStorageGroupId}`)
+      }
+    }
+  }, [url, setUrlWithParams, isActive, group, lecturer])
 
   return (
     <Tab active={isActive} onClick={tabClick}>
-      <UnstyledLink to={url}>
+      <UnstyledLink to={urlWithParams}>
         {children}
       </UnstyledLink>
     </Tab>
@@ -17,3 +39,4 @@ const ScheduleTypeTab = ({tabClick, activeTab, children, url}) => {
 };
 
 export default ScheduleTypeTab;
+

--- a/src/components/scheduleTypeTab/scheduleTypeTab.jsx
+++ b/src/components/scheduleTypeTab/scheduleTypeTab.jsx
@@ -5,6 +5,7 @@ import { routes } from '../../common/constants/routes';
 import { useEffect, useState } from 'react';
 import { useGroupContext } from '../../common/context/groupContext';
 import { useLecturerContext } from '../../common/context/lecturerContext';
+import { getLocalStorageItem } from '../../common/utils/parsedLocalStorage';
 
 const ScheduleTypeTab = ({tabClick, activeTab, children, url}) => {
   const location = useLocation();
@@ -16,13 +17,13 @@ const ScheduleTypeTab = ({tabClick, activeTab, children, url}) => {
 
   useEffect(() => {
     if(url.includes(routes.LECTURER)){
-      const localStorageLecturerId = localStorage.getItem("lecturerId")
+      const localStorageLecturerId = getLocalStorageItem("lecturerId")
       if(localStorageLecturerId){
         setUrlWithParams(`${url}?groupId=${localStorageLecturerId}`)
       }
     }
     else if(url.includes(routes.GROUP) || url.includes(routes.SESSION)){
-      const localStorageGroupId = localStorage.getItem("groupId")
+      const localStorageGroupId = getLocalStorageItem("groupId")
       if(localStorageGroupId){
         setUrlWithParams(`${url}?groupId=${localStorageGroupId}`)
       }

--- a/src/components/switch/switch.jsx
+++ b/src/components/switch/switch.jsx
@@ -1,11 +1,12 @@
 import './switch.scss';
 import { useTheme } from 'styled-components';
 import { useEffect, useState } from 'react';
+import clsx from 'clsx';
 
 const Switch = ({onChange}) => {
   const theme = useTheme();
 
-  const [checked, setChecked] = useState(true);
+  const [checked, setChecked] = useState(undefined);
 
   useEffect(() => {
     const localStorageTheme = localStorage.getItem("theme")
@@ -28,9 +29,16 @@ const Switch = ({onChange}) => {
   return (
     <>
       <label className="switch">
-        <input onChange={onCheckboxChange} checked={checked} type="checkbox"/>
-        <span style={{'backgroundColor': theme['bgOptions']}} className="slider round"/>
-        <span className="checker"/>
+        <input onChange={onCheckboxChange} checked={checked === undefined ? true : checked} type="checkbox"/>
+        <span style={{'backgroundColor': theme['bgOptions']}}
+        className={clsx(
+          {"slider round": true},
+          {"hidden": checked === undefined}
+          )}/>
+        <span className={clsx(
+          {"checker": true},
+          {"hidden": checked === undefined}
+          )}/>
       </label>
     </>
   );

--- a/src/components/switch/switch.jsx
+++ b/src/components/switch/switch.jsx
@@ -2,6 +2,7 @@ import './switch.scss';
 import { useTheme } from 'styled-components';
 import { useEffect, useState } from 'react';
 import clsx from 'clsx';
+import { getLocalStorageItem } from '../../common/utils/parsedLocalStorage';
 
 const Switch = ({onChange}) => {
   const theme = useTheme();
@@ -9,7 +10,7 @@ const Switch = ({onChange}) => {
   const [checked, setChecked] = useState(undefined);
 
   useEffect(() => {
-    const localStorageTheme = localStorage.getItem("theme")
+    const localStorageTheme = getLocalStorageItem("theme")
     const prefersLight = window.matchMedia('(prefers-color-scheme: light)').matches;
     if(localStorageTheme){
       setChecked(localStorageTheme === 'light')

--- a/src/components/switch/switch.scss
+++ b/src/components/switch/switch.scss
@@ -54,16 +54,16 @@
   transition: .4s;
 }
 
-input:checked + .slider:before {
+input:checked+.slider:before {
   transform: translateX(26px);
 }
 
 
-input:not(:checked) ~ .checker:after {
+input:not(:checked)~.checker:after {
   opacity: 0;
 }
 
-input:checked ~ .checker:before {
+input:checked~.checker:before {
   opacity: 0;
 }
 
@@ -74,4 +74,8 @@ input:checked ~ .checker:before {
 
 .slider.round:before {
   border-radius: 50%;
+}
+
+.hidden {
+  display: none;
 }

--- a/src/containers/scheduleItemExtended/scheduleItemExtended.jsx
+++ b/src/containers/scheduleItemExtended/scheduleItemExtended.jsx
@@ -7,15 +7,11 @@ const ScheduleItemExtended = ({scheduleItemData}) => {
   const [hasData, setHasData] = useState(true)
 
   useEffect(() => {
-    let count = 0
-    let countEmpty = 0
-    scheduleItemData.forEach(item => {
-        count++
-        if(item.teacherName === "" && item.place === ""){
-          countEmpty++
-        }
-    })
-    if(count === countEmpty){
+    const countEmpty = scheduleItemData.reduce((totalEmpty, currentItem) => {
+      return totalEmpty + (currentItem.teacherName === "" && currentItem.place === "")
+    }, 0)
+    
+    if(countEmpty === scheduleItemData.length){
       setHasData(false)
     }
   }, [scheduleItemData])

--- a/src/containers/scheduleItemExtended/scheduleItemExtended.jsx
+++ b/src/containers/scheduleItemExtended/scheduleItemExtended.jsx
@@ -1,9 +1,24 @@
 import { ScheduleItemExtendedUnit, ScheduleItemExtendedWrapper, CollapseItem } from './scheduleItemExtended.style';
 import ScheduleItemContent from '../../components/scheduleItemContent';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const ScheduleItemExtended = ({scheduleItemData}) => {
   const [collapsed, setCollapse] = useState(true);
+  const [hasData, setHasData] = useState(true)
+
+  useEffect(() => {
+    let count = 0
+    let countEmpty = 0
+    scheduleItemData.forEach(item => {
+        count++
+        if(item.teacherName === "" && item.place === ""){
+          countEmpty++
+        }
+    })
+    if(count === countEmpty){
+      setHasData(false)
+    }
+  }, [scheduleItemData])
 
   const generateScheduleUnits = () => {
     return scheduleItemData.map((item, i) => {
@@ -18,7 +33,7 @@ const ScheduleItemExtended = ({scheduleItemData}) => {
   return scheduleItemData && scheduleItemData.length ? (
     <ScheduleItemExtendedWrapper items={scheduleItemData.length}>
       {generateScheduleUnits()}
-      <CollapseItem onClick={() => setCollapse(value => !value)}>{collapsed ? 'Більше інформації' : 'Менше інформації'}</CollapseItem>
+      {hasData && <CollapseItem onClick={() => setCollapse(value => !value)}>{collapsed ? 'Більше інформації' : 'Менше інформації'}</CollapseItem>}
     </ScheduleItemExtendedWrapper>
   ) : null;
 };

--- a/src/containers/scheduleTypeTabs/scheduleTypeTabs.jsx
+++ b/src/containers/scheduleTypeTabs/scheduleTypeTabs.jsx
@@ -1,12 +1,8 @@
-import Tabs from '../tabs';
 import ScheduleTypeTab from '../../components/scheduleTypeTab';
-import { useHistory } from 'react-router-dom';
 import { TabContainer } from './scheduleTypeTabs.style';
 import { routes } from '../../common/constants/routes';
 
 const ScheduleTypeTabs = () => {
-  const history = useHistory();
-
   const tabs = [
     {value: routes.GROUP, label: 'Розклад занять'},
     {value: routes.SESSION, label: 'Розклад сесії'},

--- a/src/containers/scheduleWrapper/scheduleWrapper.jsx
+++ b/src/containers/scheduleWrapper/scheduleWrapper.jsx
@@ -31,7 +31,7 @@ const ScheduleWrapper = ({getData, contextType}) => {
     } else {
       setData(null);
     }
-  }, [lecturer, group]);
+  }, [lecturer, group, contextType, getData]);
 
   const generateScheduleRows = (scheduleMatrix) => {
     return scheduleMatrix.map((item, i) => {

--- a/src/containers/scrollToTop/index.js
+++ b/src/containers/scrollToTop/index.js
@@ -1,0 +1,3 @@
+import ScrollToTop from "./scrollToTop";
+
+export default ScrollToTop;

--- a/src/containers/scrollToTop/scrollToTop.jsx
+++ b/src/containers/scrollToTop/scrollToTop.jsx
@@ -1,0 +1,18 @@
+import { useEffect, Fragment } from 'react';
+import { withRouter } from 'react-router-dom';
+
+// Scroll to top on location change
+const ScrollToTop = ({ history, children }) => {
+    useEffect(() => {
+        const unlisten = history.listen(() => {
+            window.scrollTo(0, 0);
+        });
+        return () => {
+            unlisten();
+        }
+    }, [history]);
+
+    return <Fragment>{children}</Fragment>;
+}
+
+export default withRouter(ScrollToTop);


### PR DESCRIPTION
- Added local storage saves, so groups and lecturers are saved on page reload
- Added clickable location links
- Added page scroll to page top on location change
- Fixed groups duplicates
- Fixed incorrect theme changer input visualization on page reload
- Fixed incorrect groups links in lecturer view
- 'Show more' button is now not shown if there is no additional data available