### PR TITLE
Fixed wrapping of long groups list

### DIFF
--- a/src/containers/ScheduleItem/GroupProperty.tsx
+++ b/src/containers/ScheduleItem/GroupProperty.tsx
@@ -5,10 +5,15 @@ import { useStore } from '../../store';
 import { routes } from '../../common/constants/routes';
 import { Group } from '../../models/Group';
 import React from 'react';
+import styled from 'styled-components';
 
 interface Props {
   groups: Group[];
 }
+
+const WrappedProperty = styled(Property)`
+  flex-wrap: wrap;
+`;
 
 const GroupProperty = ({ groups }: Props) => {
   const setGroup = useStore((store) => store.setGroup);
@@ -29,18 +34,16 @@ const GroupProperty = ({ groups }: Props) => {
   };
 
   return (
-    <Property>
-      {groups.map((group, index) => {
-        return (
-          <React.Fragment key={group.id}>
-            <StyledLink onClick={handleGroupClick(group)} key={group.id} to={getGroupLink(group.id)}>
-              {group.name}
-              {index < groups.length - 1 && ', '}
-            </StyledLink>
-          </React.Fragment>
-        );
-      })}
-    </Property>
+    <WrappedProperty>
+      {groups.map((group, index) => (
+        <React.Fragment key={group.id}>
+          <StyledLink onClick={handleGroupClick(group)} key={group.id} to={getGroupLink(group.id)}>
+            {group.name}
+            {index < groups.length - 1 && ', '}
+          </StyledLink>
+        </React.Fragment>
+      ))}
+    </WrappedProperty>
   );
 };
 

--- a/src/containers/ScheduleItem/Property.styled.tsx
+++ b/src/containers/ScheduleItem/Property.styled.tsx
@@ -12,7 +12,6 @@ export const Property = styled(Flex)`
   display: flex;
   align-items: start;
   gap: 4px;
-  flex-wrap: wrap;
 
   & > svg {
     margin-top: 1px;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved readability of schedule item group names: long names now wrap onto multiple lines, preventing overflow and clipping.
  * Other property labels remain single-line for a cleaner, more compact layout across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->