### PR TITLE
Fixed shrinking icon in property items, padding in extended schedule …

### DIFF
--- a/src/containers/ScheduleItem/IrregularSchedulesTable.tsx
+++ b/src/containers/ScheduleItem/IrregularSchedulesTable.tsx
@@ -53,7 +53,7 @@ const DateListItem = styled.div<{ $period: EventPeriod }>`
   ${(props) =>
     props.$period === 'past' &&
     css`
-      &:first-child time {
+      time {
         text-decoration: line-through;
       }
     `}

--- a/src/containers/ScheduleItem/IrregularSchedulesTable.tsx
+++ b/src/containers/ScheduleItem/IrregularSchedulesTable.tsx
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import { getValueFromTheme } from '../../common/utils/getValueFromTheme';
 import dayjs from 'dayjs';
+import { useMemo } from 'react';
 
 interface IrregularSchedulesTableProps {
   dates: string[];
@@ -78,12 +79,14 @@ const getDatePeriod = (date: string): EventPeriod => {
 };
 
 export const IrregularSchedulesTable = ({ dates }: IrregularSchedulesTableProps) => {
+  const sortedDates = useMemo(() => dates.sort((a, b) => dayjs(a).valueOf() - dayjs(b).valueOf()), [dates]);
+
   return (
     <Wrapper>
       <Header>Розклад спец. занять</Header>
       <Divider />
       <DatesList>
-        {dates.map((date) => {
+        {sortedDates.map((date) => {
           const period = getDatePeriod(date);
           return (
             <DateListItem $period={period} key={date}>

--- a/src/containers/ScheduleItem/LecturerScheduleContent.tsx
+++ b/src/containers/ScheduleItem/LecturerScheduleContent.tsx
@@ -11,13 +11,11 @@ const LecturerScheduleContent = <T extends LecturerPair>({ scheduleMatrixCell, c
   } = scheduleMatrixCell;
 
   return (
-    <>
-      <ScheduleItemBase scheduleMatrixCell={scheduleMatrixCell} collapsed={collapsed}>
-        {location && <PairLocationProperty location={location} />}
-        <GroupProperty groups={groups} />
-        {!!dates.length && <IrregularSchedulesTable dates={dates} />}
-      </ScheduleItemBase>
-    </>
+    <ScheduleItemBase scheduleMatrixCell={scheduleMatrixCell} collapsed={collapsed}>
+      {location && <PairLocationProperty location={location} />}
+      <GroupProperty groups={groups} />
+      {!!dates.length && <IrregularSchedulesTable dates={dates} />}
+    </ScheduleItemBase>
   );
 };
 

--- a/src/containers/ScheduleItem/Property.styled.tsx
+++ b/src/containers/ScheduleItem/Property.styled.tsx
@@ -11,11 +11,12 @@ export const Property = styled(Flex)`
   align-items: center;
   display: flex;
   align-items: start;
-  gap: 4px;
+  gap: 6px;
 
   & > svg {
     margin-top: 1px;
     width: 16px;
     height: 16px;
+    flex-shrink: 0;
   }
 `;

--- a/src/containers/ScheduleItem/ScheduleItemBase.tsx
+++ b/src/containers/ScheduleItem/ScheduleItemBase.tsx
@@ -45,7 +45,7 @@ const ScheduleItemCurrent = styled.span`
 const CollapsedItemsWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   margin-top: 12px;
 `;
 

--- a/src/containers/ScheduleItem/StudentScheduleContent.tsx
+++ b/src/containers/ScheduleItem/StudentScheduleContent.tsx
@@ -11,13 +11,11 @@ const StudentScheduleContent = <T extends StudentPair>({ scheduleMatrixCell, col
   } = scheduleMatrixCell;
 
   return (
-    <>
-      <ScheduleItemBase scheduleMatrixCell={scheduleMatrixCell} collapsed={collapsed}>
-        {lecturer && <LecturerProperty lecturer={lecturer} />}
-        {location && <PairLocationProperty location={location} />}
-        {!!dates.length && <IrregularSchedulesTable dates={dates} />}
-      </ScheduleItemBase>
-    </>
+    <ScheduleItemBase scheduleMatrixCell={scheduleMatrixCell} collapsed={collapsed}>
+      {lecturer && <LecturerProperty lecturer={lecturer} />}
+      {location && <PairLocationProperty location={location} />}
+      {!!dates.length && <IrregularSchedulesTable dates={dates} />}
+    </ScheduleItemBase>
   );
 };
 

--- a/src/containers/ScheduleItemExtended/ScheduleItemExtended.style.ts
+++ b/src/containers/ScheduleItemExtended/ScheduleItemExtended.style.ts
@@ -21,7 +21,7 @@ const cutOffPart = css`
 
 export const ScheduleItemExtendedUnit = styled.div`
   ${ScheduleItemMixin};
-  padding: 20px;
+  padding: 16px;
   position: relative;
 
   &:not(:first-child):not(:last-child) {


### PR DESCRIPTION
Fixed shrinking icon in property items, padding in extended schedule items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Increased spacing between collapsed schedule items for improved readability.
  * Increased spacing in property items and prevented icons from shrinking for consistent layouts.
  * Reduced inner padding in extended schedule items to tighten content density.
  * Past irregular schedule entries now show strikethrough styling for all time entries.

* **Refactor**
  * Removed redundant wrapper elements in schedule content components; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->