### PR TITLE
fix: correct week toggle initialization

### DIFF
--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -4,7 +4,7 @@ import { RadioGroupOption, RadioGroupWrapper } from './RadioGroup.style';
 interface RadioGroupProps<T> {
   options: ListOption<T>[];
   onChange: (value: T) => void;
-  value: T;
+  value: T | null;
   fullWidth?: boolean;
   rounded?: boolean;
 }

--- a/src/containers/ScheduleTable/ScheduleTable.tsx
+++ b/src/containers/ScheduleTable/ScheduleTable.tsx
@@ -103,7 +103,7 @@ const ScheduleTable = <T extends Pair>({
     return null;
   }
 
-  const weekSchedule = schedule ? schedule[weekValue[currentWeek]] : [];
+  const weekSchedule = schedule && currentWeek ? schedule[weekValue[currentWeek]] : [];
 
   const scheduleMatrix = generateScheduleMatrix<T>(weekSchedule, timeSlots, currentTime.currentLesson);
 

--- a/src/layouts/ScheduleLayout.tsx
+++ b/src/layouts/ScheduleLayout.tsx
@@ -22,15 +22,16 @@ const Container = styled.div`
 `;
 
 export const ScheduleLayout = () => {
-  const { data } = useCurrentTime();
+  const { data, isLoading } = useCurrentTime();
   const setCurrentWeek = useWeekStore((state) => state.setCurrentWeek);
 
   useEffect(() => {
-    if (!isNil(data?.currentWeek)) {
-      const week = data?.currentWeek === 1 ? 'firstWeek' : 'secondWeek';
+    if (!isLoading) {
+      const week = data!.currentWeek === 1 ? 'firstWeek' : 'secondWeek';
       setCurrentWeek(week);
     }
-  }, [data?.currentWeek, setCurrentWeek]);
+  }, [data?.currentWeek, setCurrentWeek, isLoading]);
+
   return (
     <ScrollToTop>
       <Navbar />

--- a/src/queries/useCurrentTime.ts
+++ b/src/queries/useCurrentTime.ts
@@ -9,11 +9,6 @@ export const useCurrentTime = () => {
   return useQuery({
     staleTime: 12 * 60 * 60 * 1000,
     queryKey: getQueryKey(),
-    placeholderData: {
-      currentDay: 0,
-      currentLesson: 0,
-      currentWeek: 0,
-    },
     queryFn: getCurrentTime,
   });
 };

--- a/src/store/weekStore.tsx
+++ b/src/store/weekStore.tsx
@@ -2,11 +2,11 @@ import { create } from 'zustand';
 import { Week } from '../types/Week';
 
 type WeekStore = {
-  currentWeek: Week;
+  currentWeek: Week | null;
   setCurrentWeek: (week: Week) => void;
 };
 
 export const useWeekStore = create<WeekStore>((set) => ({
-  currentWeek: 'secondWeek',
+  currentWeek: null,
   setCurrentWeek: (week) => set({ currentWeek: week }),
 }));


### PR DESCRIPTION
Previously, when visiting the site, the toggle always defaulted to the second week initially,
and only afterward updated to the week received from the API.

Now, the week toggle has no active selection at first. Once the data from the API arrives,
the correct current week is displayed. This prevents displaying an incorrect default week 
before the API response.