### PR TITLE
feat: highlight ACTUAL week and ACTUAL slice in ScheduleDayToggler

### DIFF
--- a/src/common/context/SliceOptionsContext.tsx
+++ b/src/common/context/SliceOptionsContext.tsx
@@ -10,6 +10,7 @@ export type Slice = [number, number];
 export interface SliceContext {
   slice: Slice;
   setSlice: (slice: Slice) => void;
+  actualSlice: Slice;
 }
 
 const defaultValue: Slice = [0, 0];
@@ -17,6 +18,7 @@ const defaultValue: Slice = [0, 0];
 const SliceOptionsContext = createContext<SliceContext>({
   slice: defaultValue,
   setSlice: () => ({}),
+  actualSlice: defaultValue,
 });
 
 export const useSliceOptionsContext = () => useContext(SliceOptionsContext);
@@ -48,19 +50,23 @@ const getCurrentSlice = (screenSize: ScreenSize, currendDay: number): Slice => {
 };
 
 export const SliceContextProvider = ({ children }: SliceContextProviderProps) => {
-  const { data } = useCurrentTime();
+  const { data, isLoading } = useCurrentTime();
   const { screenSize } = useScreenSize();
   const [slice, setSlice] = useState<Slice>(defaultValue);
+  const [actualSlice, setActualSlice] = useState<Slice>(defaultValue);
 
   useEffect(() => {
-    if (!isNil(data?.currentDay)) {
-      setSlice(getCurrentSlice(screenSize, data?.currentDay || 0));
+    if (!isLoading && data) {
+      const currentSlice = getCurrentSlice(screenSize, data.currentDay);
+      setSlice(currentSlice);
+      setActualSlice(currentSlice);
     }
-  }, [screenSize, data?.currentDay]);
+  }, [screenSize, data, isLoading]);
 
   const value: SliceContext = {
     slice,
     setSlice,
+    actualSlice,
   };
 
   return <SliceOptionsContext.Provider value={value}>{children}</SliceOptionsContext.Provider>;

--- a/src/components/RadioGroup/RadioGroup.style.ts
+++ b/src/components/RadioGroup/RadioGroup.style.ts
@@ -13,7 +13,7 @@ export const RadioGroupWrapper = styled.div<{ $fullWidth?: boolean; $rounded?: b
   gap: 4px;
 `;
 
-export const RadioGroupOption = styled.div<{ $active: boolean; $rounded?: boolean }>`
+export const RadioGroupOption = styled.div<{ $active: boolean; $rounded?: boolean; $isActualValue?: boolean }>`
   flex-grow: 1;
   transition: 0.2s ease-in background-color;
   display: inline-flex;
@@ -53,6 +53,15 @@ export const RadioGroupOption = styled.div<{ $active: boolean; $rounded?: boolea
           color: #141518;
         `
       : ''};
+
+  ${(props) =>
+    props.$isActualValue &&
+    css`
+      text-decoration: underline;
+      text-decoration-color: ${getValueFromTheme('brand600')};
+      text-decoration-thickness: 2px;
+      text-underline-offset: 4px;
+    `};
 
   ${media.extraSmallMode} {
     padding: 6px;

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -5,6 +5,7 @@ interface RadioGroupProps<T> {
   options: ListOption<T>[];
   onChange: (value: T) => void;
   value?: T;
+  actualValue?: T;
   fullWidth?: boolean;
   rounded?: boolean;
 }
@@ -13,6 +14,7 @@ export const RadioGroup = <T extends string | number>({
   options,
   onChange,
   value,
+  actualValue,
   fullWidth,
   rounded,
 }: RadioGroupProps<T>) => (
@@ -24,6 +26,7 @@ export const RadioGroup = <T extends string | number>({
         data-text={item.label}
         $active={value === item.value}
         $rounded={rounded}
+        $isActualValue={item.value === actualValue}
       >
         {item.label}
       </RadioGroupOption>

--- a/src/components/WeekSwitch/WeekSwitch.tsx
+++ b/src/components/WeekSwitch/WeekSwitch.tsx
@@ -9,9 +9,11 @@ const WEEKS: ListOption<Week>[] = [
 ];
 
 const WeekSwitch = () => {
-  const { currentWeek, setCurrentWeek } = useWeekStore();
+  const { currentWeek, setCurrentWeek, actualWeek } = useWeekStore();
 
-  return <RadioGroup value={currentWeek} options={WEEKS} onChange={setCurrentWeek} fullWidth />;
+  return (
+    <RadioGroup value={currentWeek} actualValue={actualWeek} options={WEEKS} onChange={setCurrentWeek} fullWidth />
+  );
 };
 
 export default WeekSwitch;

--- a/src/containers/ScheduleDayToggler/ScheduleDayToggler.tsx
+++ b/src/containers/ScheduleDayToggler/ScheduleDayToggler.tsx
@@ -6,7 +6,7 @@ import { Slice, useSliceOptionsContext } from '../../common/context/SliceOptions
 
 const ScheduleDayToggler = () => {
   const { screenSize } = useScreenSize();
-  const { slice, setSlice } = useSliceOptionsContext();
+  const { slice, setSlice, actualSlice } = useSliceOptionsContext();
 
   const options = DAY_OPTIONS[screenSize];
 
@@ -24,7 +24,14 @@ const ScheduleDayToggler = () => {
 
   return (
     <ScheduleDayTogglerContainer>
-      <RadioGroup value={convertSlice(slice)} options={options} onChange={handleChange} fullWidth rounded />
+      <RadioGroup
+        value={convertSlice(slice)}
+        actualValue={convertSlice(actualSlice)}
+        options={options}
+        onChange={handleChange}
+        fullWidth
+        rounded
+      />
     </ScheduleDayTogglerContainer>
   );
 };

--- a/src/layouts/ScheduleLayout.tsx
+++ b/src/layouts/ScheduleLayout.tsx
@@ -3,7 +3,6 @@ import Navbar from '../containers/Navbar';
 import ScrollToTop from '../components/ScrollToTop';
 import { media } from '../common/styles/styles';
 import styled from 'styled-components';
-import { isNil } from 'lodash-es';
 import { useEffect } from 'react';
 import { useCurrentTime } from '../queries/useCurrentTime';
 import { useWeekStore } from '../store/weekStore';
@@ -23,14 +22,15 @@ const Container = styled.div`
 
 export const ScheduleLayout = () => {
   const { data, isLoading } = useCurrentTime();
-  const setCurrentWeek = useWeekStore((state) => state.setCurrentWeek);
+  const { setCurrentWeek, setActualWeek } = useWeekStore();
 
   useEffect(() => {
     if (!isLoading && data) {
       const week = data.currentWeek === 1 ? 'firstWeek' : 'secondWeek';
       setCurrentWeek(week);
+      setActualWeek(week);
     }
-  }, [data?.currentWeek, setCurrentWeek, isLoading]);
+  }, [data, isLoading]);
 
   return (
     <ScrollToTop>

--- a/src/store/weekStore.tsx
+++ b/src/store/weekStore.tsx
@@ -4,9 +4,15 @@ import { Week } from '../types/Week';
 type WeekStore = {
   currentWeek?: Week;
   setCurrentWeek: (week: Week) => void;
+
+  actualWeek?: Week;
+  setActualWeek: (week: Week) => void;
 };
 
 export const useWeekStore = create<WeekStore>((set) => ({
   currentWeek: undefined,
   setCurrentWeek: (week) => set({ currentWeek: week }),
+
+  actualWeek: undefined,
+  setActualWeek: (week) => set({ actualWeek: week }),
 }));


### PR DESCRIPTION
- **Summary**
This PR adds a visual indicator for the ACTUAL week and actual slice (days).
Users can now immediately see which week and day are the actual ones, 
even if a different week or day is currently selected, without needing to refresh the page.

- **Problem / Motivation**
Previously, the actual week and day were not visually indicated. Selecting a different week or day made it unclear which week/day was actual without refreshing, causing confusion.

- **What was done:**  
  - Added `actualValue` prop to `RadioGroup`.  
  - Apply underline if `actualValue` is present.  
  - Updated `WeekSwitch` and `ScheduleDayToggler` to use this feature.
  
- **Notes / Future improvements**
  - The styling can be further improved, but the main idea is implemented.
  - This feature will help users easily identify the current schedule, improving UX.

- **Screenshots**
<img width="1710" height="271" alt="Screenshot 2025-09-07 at 00 21 33" src="https://github.com/user-attachments/assets/7324bbb8-d188-44cf-9782-d81692ec08b4" />
<img width="698" height="339" alt="Screenshot 2025-09-07 at 00 22 43" src="https://github.com/user-attachments/assets/b6e9f900-59c5-418f-b004-85191f574b67" />
<img width="397" height="320" alt="Screenshot 2025-09-07 at 00 23 18" src="https://github.com/user-attachments/assets/be2b3590-acc6-4be7-b2ef-d2c27188bcd1" />
