### PR TITLE
refactor(http): add generics to Http

### DIFF
--- a/src/api/fullList.ts
+++ b/src/api/fullList.ts
@@ -7,7 +7,7 @@ export const getAllLecturers = (): Promise<EntityWithNameAndId[]> => {
 };
 
 export const getAllGroups = async (): Promise<Group[]> => {
-  const response = await Http.get('/group/all');
+  const response = await Http.get<Group[]>('/group/all');
 
   return response.map((row) => ({
     ...row,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,7 +8,7 @@ interface FetchOptions extends RequestInit {
   headers?: Record<string, string>;
 }
 
-const fetchWrapper = async (requestUrl: string, options: FetchOptions = {}) => {
+const fetchWrapper = async <T = unknown>(requestUrl: string, options: FetchOptions = {}): Promise<T> => {
   const { headers = {}, ...restOptions } = options;
 
   const requestOptions: RequestInit = {
@@ -29,7 +29,7 @@ const fetchWrapper = async (requestUrl: string, options: FetchOptions = {}) => {
 };
 
 const Http = {
-  get: (url: string, options: FetchOptions = {}) => fetchWrapper(url, { ...options, method: 'GET' }),
+  get: <T = unknown>(url: string, options: FetchOptions = {}) => fetchWrapper<T>(url, { ...options, method: 'GET' }),
 };
 
 export default Http;

--- a/src/api/time.ts
+++ b/src/api/time.ts
@@ -2,9 +2,9 @@ import { CurrentTime } from '../models/CurrentTime';
 import Http from './index';
 
 export const getCurrentTime = (): Promise<CurrentTime> => {
-  return Http.get('/time/current');
+  return Http.get<CurrentTime>('/time/current');
 };
 
 export const getTimeSlots = (): Promise<Record<string, string>> => {
-  return Http.get('/schedule/lessons/slots');
+  return Http.get<Record<string, string>>('/schedule/lessons/slots');
 };


### PR DESCRIPTION
- Refactor Http client to use generics for type-safe responses.
- Fix calls that previously received `any` as response type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced explicit typing for API responses to improve type safety.
  * Standardized generic support for GET requests across the API layer.
  * Ensured consistent types for time-related data responses.
  * No changes to public method behavior or endpoints; runtime behavior remains unchanged.
  * Improves developer experience and reduces risk of type-related issues without affecting users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->