### PR TITLE
refactor(http): add generic to Http service

### DIFF
--- a/src/api/fullList.ts
+++ b/src/api/fullList.ts
@@ -7,7 +7,7 @@ export const getAllLecturers = (): Promise<EntityWithNameAndId[]> => {
 };
 
 export const getAllGroups = async (): Promise<Group[]> => {
-  const response = await Http.get('/group/all');
+  const response = await Http.get<Group[]>('/group/all');
 
   return response.map((row) => ({
     ...row,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,7 +8,7 @@ interface FetchOptions extends RequestInit {
   headers?: Record<string, string>;
 }
 
-const fetchWrapper = async (requestUrl: string, options: FetchOptions = {}) => {
+const fetchWrapper = async <T = unknown>(requestUrl: string, options: FetchOptions = {}): Promise<T> => {
   const { headers = {}, ...restOptions } = options;
 
   const requestOptions: RequestInit = {
@@ -29,7 +29,7 @@ const fetchWrapper = async (requestUrl: string, options: FetchOptions = {}) => {
 };
 
 const Http = {
-  get: (url: string, options: FetchOptions = {}) => fetchWrapper(url, { ...options, method: 'GET' }),
+  get: <T = unknown>(url: string, options: FetchOptions = {}) => fetchWrapper<T>(url, { ...options, method: 'GET' }),
 };
 
 export default Http;


### PR DESCRIPTION
- Refactor Http service to use generic for type-safe responses.
- Fix calls that previously received `any` as response type.