### PR TITLE
KBX-1066 Move Docker build out of root dir to stop Tailwind scanning /

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # pull official base image
 FROM node:lts-alpine as builder
 RUN apk add --no-cache python3 py3-pip make g++
-# set working directory
-WORKDIR /
+# set working directory (must NOT be `/`: Tailwind 4 auto-scans the whole
+# working directory for class names, and scanning the container root —
+# /proc, /sys, /usr, ... — makes `vite build` hang until it is OOM-killed)
+WORKDIR /app
 
 COPY package*.json ./
 
@@ -22,7 +24,7 @@ RUN npm run build
 
 # production
 FROM nginx:stable-alpine
-COPY --from=builder /build /usr/share/nginx/html
+COPY --from=builder /app/build /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Jira: [KBX-1066](https://kpiua.atlassian.net/browse/KBX-1066)

## Summary
- Change `WORKDIR /` to `WORKDIR /app` in the builder stage and update the `COPY --from=builder` path accordingly.
- Fixes CI builds hanging on `vite build` (`transforming...`) for 25–80 minutes until the process is SIGKILLed by the OOM killer.

## Notes
- Root cause: Tailwind 4 (`@tailwindcss/vite`) auto-scans the whole working directory for class names. Since the Tailwind migration landed on 2026-08-10, the working directory in Docker was `/`, so the scan covered the entire container filesystem (`/proc`, `/sys`, `/usr`, ...). The first hanging build (#43) is from the same day.
- The `GOMAXPROCS` / `NODE_OPTIONS` limits from `e21f030` did not address this and are left in place as harmless.
- Verified locally: `docker build` now completes the `vite build` step in ~3s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KBX-1066]: https://kpiua.atlassian.net/browse/KBX-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ